### PR TITLE
Adjust compiler options to make binary portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.2)
 project (vdlm2dec C)
 
-add_compile_options(-Ofast -march=native )
+add_compile_options(-O2)
 
 add_executable(vdlm2dec cJSON.c  crc.c  d8psk.c  label.c  main.c  outacars.c  out.c  outxid.c  rs.c  vdlm2.c  viterbi.c )
 


### PR DESCRIPTION
`-Ofast` and especially `-march=native` produce binaries that are not portable. Changed to `-O2`.